### PR TITLE
Add testing Dockerfile and explanation on how to use it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -yq sudo curl
+
+# Turn on passwordless sudo for ubuntu
+RUN echo 'ubuntu ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+RUN useradd ubuntu -m
+
+WORKDIR /home/ubuntu
+
+USER ubuntu

--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ internet:
 ```bash
 curl -fL init.chevalierforget.com | bash
 ```
+
+
+## Try it out in a Docker container
+
+Give this repo a try in a docker container using the Dockerfile:
+
+```bash
+curl -fL https://raw.githubusercontent.com/philipforget/dotfiles/master/Dockerfile | \
+  docker build -t dotfiles-test - && \
+  docker run --rm -it dotfiles-test  \
+    bash -c 'curl -fL init.chevalierforget.com | bash; /bin/bash'
+```
+
+You'll be dropped into a container after it finishes running `init.sh` for the `ubuntu` user.

--- a/init.sh
+++ b/init.sh
@@ -112,6 +112,9 @@ init() {
     setup_virtualenv
     setup_dotfiles
 
+    echo "Installing vim plugins"
+    vim -E +PlugInstall +qall &> /dev/null
+
     echo "setup complete, run 'source ~/.bashrc' to source changes"
 }
 


### PR DESCRIPTION
Adds a Dockerfile for quickly and easily testing the init script as well as a README entry for using it directly from github to build and run a container to test the dotfiles.