### PR TITLE
fix bash-completion typo

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -77,7 +77,7 @@ install_packages() {
         fi
         brew install \
             bash \
-            bash-complation \
+            bash-completion \
             git \
             mosh \
             python3 \


### PR DESCRIPTION
As the title says. I think you mean `bash-completion` not `bash-complation`.